### PR TITLE
Fix errors with irregular batch sizes during inferences

### DIFF
--- a/rlprompt/models/single_prompt_model.py
+++ b/rlprompt/models/single_prompt_model.py
@@ -34,7 +34,7 @@ class SinglePromptModel(BaseModel):
         **kwargs
     ) -> Dict[str, Any]:
         if infer: 
-            batch_size = self.prompt_infer_batch_size
+            batch_size = min(self.prompt_infer_batch_size, len(source_texts))
         else: 
             batch_size = self.prompt_train_batch_size
         prompt_source = self._get_prompt_source(batch_size=batch_size)


### PR DESCRIPTION
Fixed the bug raised in Issue #15, where during training for text style transfer on the Shakespeare dataset, an assertion statement would be triggered due to irregular batch sizes